### PR TITLE
Add LoadLibraryExW to find DLL only from System32

### DIFF
--- a/main.c
+++ b/main.c
@@ -6,12 +6,6 @@
  * http://opensource.org/licenses/mit-license.php
  */
 
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <wchar.h>
-#include <windows.h>
 #include "wsld.h"
 
 #define ARRAY_LENGTH(a) (sizeof(a)/sizeof(a[0]))

--- a/main.c
+++ b/main.c
@@ -17,11 +17,9 @@
 #define ARRAY_LENGTH(a) (sizeof(a)/sizeof(a[0]))
 
 
-int main(int argc,char *argv[])
+int main(int wargc,wchar_t *wargv[])
 {
     int res = 0;
-    wchar_t **wargv;
-    int wargc;
     wargv = CommandLineToArgvW(GetCommandLineW(),&wargc);
 
     //Get file name of exe

--- a/wsld.h
+++ b/wsld.h
@@ -10,6 +10,9 @@
  #define WSLD_H_
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
 #include <windows.h>
 
 #ifdef __cplusplus

--- a/wsld.h
+++ b/wsld.h
@@ -42,7 +42,7 @@ void WslApiFree()
 
 int WslApiInit()
 {
-    WslHmod = LoadLibraryW(L"wslapi.dll");
+    WslHmod = LoadLibraryExW(L"wslapi.dll", NULL, 0x00000800);
     if (WslHmod == NULL) {
         return 1;
     }


### PR DESCRIPTION
After reading this article [Secure loading of libraries to prevent DLL preloading attacks](https://support.microsoft.com/en-us/help/2389418/secure-loading-of-libraries-to-prevent-dll-preloading-attacks), I find that [`LoadLibraryW`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms684175(v=vs.85).aspx) function first searches DLL from the directory where the executable was launched.

That may be vulnerable if some malicious DLL was placed in that place. So adding [`LoadLibraryExW`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms684179(v=vs.85).aspx) with dwFlags that automatically searches DLL from System32.
```
LOAD_LIBRARY_SEARCH_SYSTEM32
0x00000800
```
